### PR TITLE
[Preprocess] Split adaptation

### DIFF
--- a/src/Preprocess/split.c
+++ b/src/Preprocess/split.c
@@ -22,7 +22,7 @@ SDL_Surface* crop_surface(SDL_Surface* grid, int x, int y,
 
 SDL_Surface **split_sudoku(SDL_Surface* grid)
 {
-    SDL_Surface *splitted = calloc(81, sizeof(SDL_Surface *));
+    SDL_Surface **splitted = calloc(81, sizeof(SDL_Surface *));
     int h_step = grid->h / 9;
     int w_step = grid->w / 9;
 
@@ -30,4 +30,6 @@ SDL_Surface **split_sudoku(SDL_Surface* grid)
         for (int j = 0; j < 9;j++)
             splitted[i * 9 + j] = crop_surface(
                     grid, j * w_step, i * h_step, w_step, h_step);
+
+    return splitted;
 }

--- a/src/Preprocess/split.c
+++ b/src/Preprocess/split.c
@@ -20,8 +20,9 @@ SDL_Surface* crop_surface(SDL_Surface* grid, int x, int y,
     return dest_surface;
 }
 
-void split_sudoku(SDL_Surface* grid, SDL_Surface *splitted[81])
+SDL_Surface **split_sudoku(SDL_Surface* grid)
 {
+    SDL_Surface *splitted = calloc(81, sizeof(SDL_Surface *));
     int h_step = grid->h / 9;
     int w_step = grid->w / 9;
 

--- a/src/Preprocess/split.h
+++ b/src/Preprocess/split.h
@@ -6,7 +6,7 @@
 
 SDL_Surface* crop_surface(SDL_Surface* grid, int x, int y, 
                           int width, int height);
-void split_sudoku(SDL_Surface* grid, SDL_Surface *splitted[81]);
+SDL_Surface **split_sudoku(SDL_Surface* grid);
 
 #endif
 

--- a/src/main.c
+++ b/src/main.c
@@ -172,8 +172,7 @@ int main(int argc, char **argv) {
             exit_help(1);
 
         SDL_Surface *image = load_image(argv[2]);
-        SDL_Surface *splitted[81] = {NULL};
-        split_sudoku(image, splitted);
+        SDL_Surface **splitted = split_sudoku(image);
 
         for (size_t i = 0; i < 81; i++) {
             char str[3] = {0};


### PR DESCRIPTION
You don't need to pass the SDL_Surface list to the split function. It allocate it on the heap. 